### PR TITLE
feat: Implement Parent App UI for Viewing Call Logs

### DIFF
--- a/ChildMonitoringChildApp/app/src/main/AndroidManifest.xml
+++ b/ChildMonitoringChildApp/app/src/main/AndroidManifest.xml
@@ -24,6 +24,15 @@
     <!-- Notification Permission (for Android 13+ / API 33+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
+    <!-- Call Log Permission -->
+    <uses-permission android:name="android.permission.READ_CALL_LOG" />
+
+    <!-- SMS Permission -->
+    <uses-permission android:name="android.permission.READ_SMS" />
+
+    <!-- Contacts Permission -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+
 
     <application
         android:allowBackup="true"

--- a/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/CallLogEntry.java
+++ b/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/CallLogEntry.java
@@ -1,0 +1,71 @@
+package com.example.childmonitoringchildapp;
+
+import android.provider.CallLog; // For CallLog.Calls.TYPE constants
+
+import com.google.firebase.firestore.ServerTimestamp; // For @ServerTimestamp annotation
+import java.util.Date; // For Date object
+
+public class CallLogEntry {
+    private String type;         // e.g., "INCOMING", "OUTGOING", "MISSED"
+    private String phoneNumber;  // The phone number
+    private long duration;       // Call duration in seconds
+    private @ServerTimestamp Date date; // Firestore server ingestion timestamp
+    private long callDateMillis;         // Original timestamp of the call from device log
+    private String contactName;          // (Optional) Contact name if found
+
+    // Required empty public constructor for Firestore deserialization
+    public CallLogEntry() {}
+
+    public CallLogEntry(int callType, String phoneNumber, long duration, long callDateMillis, String contactName) {
+        this.type = getCallTypeString(callType);
+        this.phoneNumber = phoneNumber;
+        this.duration = duration;
+        this.callDateMillis = callDateMillis; // Store original call time
+        this.contactName = contactName != null ? contactName : ""; // Ensure not null
+        // 'date' field (server timestamp) will be set by Firestore
+    }
+
+    // Getters and Setters
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+
+    public long getDuration() { return duration; }
+    public void setDuration(long duration) { this.duration = duration; }
+
+    public Date getDate() { return date; }
+    public void setDate(Date date) { this.date = date; }
+
+    public long getCallDateMillis() { return callDateMillis; }
+    public void setCallDateMillis(long callDateMillis) { this.callDateMillis = callDateMillis; }
+
+    public String getContactName() { return contactName; }
+    public void setContactName(String contactName) { this.contactName = contactName; }
+
+
+    /**
+     * Helper method to convert CallLog.Calls.TYPE integer to a readable string.
+     * @param callType The integer type from CallLog.Calls.TYPE.
+     * @return String representation of the call type.
+     */
+    public static String getCallTypeString(int callType) {
+        switch (callType) {
+            case CallLog.Calls.INCOMING_TYPE:
+                return "INCOMING";
+            case CallLog.Calls.OUTGOING_TYPE:
+                return "OUTGOING";
+            case CallLog.Calls.MISSED_TYPE:
+                return "MISSED";
+            case CallLog.Calls.VOICEMAIL_TYPE:
+                return "VOICEMAIL";
+            case CallLog.Calls.REJECTED_TYPE:
+                return "REJECTED";
+            case CallLog.Calls.BLOCKED_TYPE:
+                return "BLOCKED";
+            default:
+                return "UNKNOWN (" + callType + ")";
+        }
+    }
+}

--- a/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/CallLogUtil.java
+++ b/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/CallLogUtil.java
@@ -1,0 +1,121 @@
+package com.example.childmonitoringchildapp;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.CallLog;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Date; // For using in CallLogEntry if not using @ServerTimestamp primarily
+import java.util.List;
+
+public class CallLogUtil {
+
+    private static final String TAG = "CallLogUtil";
+
+    /**
+     * Fetches call logs from the device after a specified timestamp.
+     *
+     * @param context         The application context.
+     * @param lastFetchTimeMs Timestamp (in milliseconds since epoch) of the last fetch.
+     *                        Only calls newer than this will be fetched.
+     *                        Pass 0 to fetch all available (or up to a reasonable limit).
+     * @return A list of CallLogEntry objects.
+     */
+    public static List<CallLogEntry> getCallLogsAfter(Context context, long lastFetchTimeMs) {
+        List<CallLogEntry> callLogEntries = new ArrayList<>();
+        ContentResolver contentResolver = context.getContentResolver();
+        Uri callLogUri = CallLog.Calls.CONTENT_URI;
+
+        // Columns to fetch
+        String[] projection = {
+                CallLog.Calls.TYPE,
+                CallLog.Calls.NUMBER,
+                CallLog.Calls.DATE,     // Date the call occurred, in milliseconds since epoch
+                CallLog.Calls.DURATION, // Duration of the call in seconds
+                // CallLog.Calls.CACHED_NAME // Optional: Contact name (requires READ_CONTACTS too)
+        };
+
+        // Selection: Fetch calls newer than lastFetchTimeMs
+        String selection = CallLog.Calls.DATE + " > ?";
+        String[] selectionArgs = {String.valueOf(lastFetchTimeMs)};
+
+        // Sort order: Newest calls first (optional, but good for limiting if needed)
+        String sortOrder = CallLog.Calls.DATE + " DESC";
+        // To limit number of results, you can append " LIMIT N" to sortOrder if not using ContentProvider limit argument
+
+        Cursor cursor = null;
+        try {
+            cursor = contentResolver.query(callLogUri, projection, selection, selectionArgs, sortOrder);
+
+            if (cursor != null && cursor.moveToFirst()) {
+                int typeIndex = cursor.getColumnIndex(CallLog.Calls.TYPE);
+                int numberIndex = cursor.getColumnIndex(CallLog.Calls.NUMBER);
+                int dateIndex = cursor.getColumnIndex(CallLog.Calls.DATE);
+                int durationIndex = cursor.getColumnIndex(CallLog.Calls.DURATION);
+                // int nameIndex = cursor.getColumnIndex(CallLog.Calls.CACHED_NAME); // If fetching name
+
+                do {
+                    int type = cursor.getInt(typeIndex);
+                    String number = cursor.getString(numberIndex);
+                    long dateMillis = cursor.getLong(dateIndex);
+                    long duration = cursor.getLong(durationIndex);
+                    // String name = (nameIndex != -1) ? cursor.getString(nameIndex) : null;
+                    String name = null; // Not fetching name in this phase
+
+                    if (number == null) number = "Unknown"; // Handle cases where number might be null (e.g. private)
+
+                    // Note: CallLogEntry's 'date' field is @ServerTimestamp.
+                    // We pass 'dateMillis' from the call log to the constructor,
+                    // but it's primarily for record-keeping or if we decide to use client-time.
+                    // The actual 'date' field in Firestore will be the server's ingestion time.
+                    callLogEntries.add(new CallLogEntry(type, number, duration, dateMillis, name));
+
+                } while (cursor.moveToNext());
+                Log.d(TAG, "Fetched " + callLogEntries.size() + " call logs after " + new Date(lastFetchTimeMs).toString());
+            } else {
+                Log.d(TAG, "No call logs found after " + new Date(lastFetchTimeMs).toString());
+            }
+        } catch (SecurityException e) {
+            Log.e(TAG, "SecurityException: READ_CALL_LOG permission might be missing or revoked.", e);
+            // This should be handled by requesting permission in MainActivity.
+            // If it still occurs, it's a problem.
+        } catch (Exception e) {
+            Log.e(TAG, "Error fetching call logs: ", e);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return callLogEntries;
+    }
+
+    /**
+     * Gets the timestamp of the most recent call log entry.
+     * Can be used to determine the 'lastFetchTimeMs' for the next fetch.
+     * @param context The application context.
+     * @return Timestamp in milliseconds, or 0 if no call logs.
+     */
+    public static long getTimestampOfLatestCall(Context context) {
+        ContentResolver contentResolver = context.getContentResolver();
+        Uri callLogUri = CallLog.Calls.CONTENT_URI;
+        String[] projection = { CallLog.Calls.DATE };
+        String sortOrder = CallLog.Calls.DATE + " DESC LIMIT 1";
+        Cursor cursor = null;
+        try {
+            cursor = contentResolver.query(callLogUri, projection, null, null, sortOrder);
+            if (cursor != null && cursor.moveToFirst()) {
+                return cursor.getLong(cursor.getColumnIndex(CallLog.Calls.DATE));
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error getting timestamp of latest call: ", e);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return 0;
+    }
+}

--- a/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/ContactEntry.java
+++ b/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/ContactEntry.java
@@ -1,0 +1,58 @@
+package com.example.childmonitoringchildapp;
+
+import java.util.List;
+import java.util.Map;
+
+// Note: This POJO is intended to be part of a list within a single Firestore document,
+// rather than each ContactEntry being a separate document itself.
+// Thus, it doesn't need @ServerTimestamp for each entry, but rather the parent document
+// holding the list of contacts would have a timestamp.
+// However, if we were to store each contact as a separate doc, @ServerTimestamp would be here.
+
+public class ContactEntry {
+    private long contactId; // Original ID from device ContactsContract.Contacts._ID
+    private String displayName;
+    private List<Map<String, String>> phoneNumbers; // List of maps, e.g., [{"type": "Mobile", "number": "123"}, ...]
+    // private List<Map<String, String>> emails; // Optional for future
+
+    // Required empty public constructor for Firestore deserialization (if used directly)
+    // or for object mappers like Gson if serializing a list of these.
+    public ContactEntry() {}
+
+    public ContactEntry(long contactId, String displayName, List<Map<String, String>> phoneNumbers) {
+        this.contactId = contactId;
+        this.displayName = displayName;
+        this.phoneNumbers = phoneNumbers;
+    }
+
+    // Getters and Setters
+    public long getContactId() {
+        return contactId;
+    }
+
+    public void setContactId(long contactId) {
+        this.contactId = contactId;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public List<Map<String, String>> getPhoneNumbers() {
+        return phoneNumbers;
+    }
+
+    public void setPhoneNumbers(List<Map<String, String>> phoneNumbers) {
+        this.phoneNumbers = phoneNumbers;
+    }
+
+    // Example of how a phone number map would look:
+    // Map<String, String> phone = new HashMap<>();
+    // phone.put("type", "Mobile");
+    // phone.put("number", "555-1234");
+    // phoneNumbers.add(phone);
+}

--- a/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/ContactsUtil.java
+++ b/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/ContactsUtil.java
@@ -1,0 +1,115 @@
+package com.example.childmonitoringchildapp;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.ContactsContract;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ContactsUtil {
+
+    private static final String TAG = "ContactsUtil";
+
+    /**
+     * Fetches all contacts from the device.
+     * Each contact will include their display name and a list of phone numbers (with types).
+     *
+     * @param context The application context.
+     * @return A list of ContactEntry objects.
+     */
+    public static List<ContactEntry> getAllContacts(Context context) {
+        List<ContactEntry> contactEntries = new ArrayList<>();
+        ContentResolver contentResolver = context.getContentResolver();
+
+        // URI for querying contacts
+        Uri contactsUri = ContactsContract.Contacts.CONTENT_URI;
+        // Columns to fetch from Contacts table
+        String[] contactsProjection = {
+                ContactsContract.Contacts._ID,
+                ContactsContract.Contacts.DISPLAY_NAME_PRIMARY,
+                ContactsContract.Contacts.HAS_PHONE_NUMBER // To quickly filter contacts with phone numbers
+        };
+
+        Cursor contactsCursor = null;
+        try {
+            contactsCursor = contentResolver.query(contactsUri, contactsProjection, null, null,
+                    ContactsContract.Contacts.DISPLAY_NAME_PRIMARY + " ASC");
+
+            if (contactsCursor != null && contactsCursor.moveToFirst()) {
+                int idIndex = contactsCursor.getColumnIndex(ContactsContract.Contacts._ID);
+                int nameIndex = contactsCursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME_PRIMARY);
+                int hasPhoneIndex = contactsCursor.getColumnIndex(ContactsContract.Contacts.HAS_PHONE_NUMBER);
+
+                while (contactsCursor.moveToNext()) {
+                    long contactId = contactsCursor.getLong(idIndex);
+                    String displayName = contactsCursor.getString(nameIndex);
+                    int hasPhoneNumber = contactsCursor.getInt(hasPhoneIndex);
+
+                    List<Map<String, String>> phoneNumbers = new ArrayList<>();
+
+                    if (hasPhoneNumber > 0) { // Check if contact has at least one phone number
+                        // URI for querying phone numbers for this contact
+                        Uri phoneUri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI;
+                        String[] phoneProjection = {
+                                ContactsContract.CommonDataKinds.Phone.NUMBER,
+                                ContactsContract.CommonDataKinds.Phone.TYPE
+                        };
+                        // Selection to get phone numbers for the current contactId
+                        String phoneSelection = ContactsContract.CommonDataKinds.Phone.CONTACT_ID + " = ?";
+                        String[] phoneSelectionArgs = {String.valueOf(contactId)};
+
+                        Cursor phoneCursor = null;
+                        try {
+                            phoneCursor = contentResolver.query(phoneUri, phoneProjection, phoneSelection, phoneSelectionArgs, null);
+                            if (phoneCursor != null && phoneCursor.moveToFirst()) {
+                                int numberPhoneIndex = phoneCursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER);
+                                int typePhoneIndex = phoneCursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.TYPE);
+
+                                do {
+                                    String number = phoneCursor.getString(numberPhoneIndex);
+                                    int type = phoneCursor.getInt(typePhoneIndex);
+                                    String typeLabel = (String) ContactsContract.CommonDataKinds.Phone.getTypeLabel(context.getResources(), type, "");
+
+                                    Map<String, String> phoneDetail = new HashMap<>();
+                                    phoneDetail.put("number", number);
+                                    phoneDetail.put("type", typeLabel);
+                                    phoneNumbers.add(phoneDetail);
+                                } while (phoneCursor.moveToNext());
+                            }
+                        } catch (Exception e) {
+                            Log.e(TAG, "Error querying phone numbers for contactId " + contactId, e);
+                        } finally {
+                            if (phoneCursor != null) {
+                                phoneCursor.close();
+                            }
+                        }
+                    }
+                    // Only add contact if they have a display name and at least one phone number (optional criteria)
+                    // For now, add even if no phone numbers were found after checking HAS_PHONE_NUMBER,
+                    // as HAS_PHONE_NUMBER is just a hint. The actual query confirms.
+                    if (displayName != null && !displayName.isEmpty()) {
+                         contactEntries.add(new ContactEntry(contactId, displayName, phoneNumbers));
+                    }
+                }
+                Log.d(TAG, "Fetched " + contactEntries.size() + " contacts.");
+            } else {
+                Log.d(TAG, "No contacts found on the device.");
+            }
+        } catch (SecurityException e) {
+            Log.e(TAG, "SecurityException: READ_CONTACTS permission might be missing or revoked.", e);
+        } catch (Exception e) {
+            Log.e(TAG, "Error fetching contacts: ", e);
+        } finally {
+            if (contactsCursor != null) {
+                contactsCursor.close();
+            }
+        }
+        return contactEntries;
+    }
+}

--- a/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/LocationReportService.java
+++ b/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/LocationReportService.java
@@ -6,15 +6,18 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.location.Location;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat; // Added ContextCompat
 import androidx.core.app.NotificationCompat;
 
 import com.google.android.gms.location.FusedLocationProviderClient;
@@ -27,6 +30,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.SetOptions;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class LocationReportService extends Service {
@@ -37,10 +41,32 @@ public class LocationReportService extends Service {
     private static final long LOCATION_UPDATE_INTERVAL = 60000; // 60 seconds
     private static final long FASTEST_LOCATION_UPDATE_INTERVAL = 30000; // 30 seconds
 
+    // For Call Log monitoring
+    private static final String PREFS_CHILD_APP = "ChildAppPrefs"; // Matches MainActivity
+    private static final String KEY_LAST_CALL_LOG_UPLOAD_TIME = "lastCallLogUploadTimeMs";
+    public static final String KEY_CALL_LOG_MONITORING_ENABLED = "callLogMonitoringEnabled";
+    private static final long CALL_LOG_UPLOAD_INTERVAL_MS = 1 * 60 * 60 * 1000;
+
+    // For SMS Log monitoring
+    private static final String KEY_LAST_SMS_LOG_UPLOAD_TIME = "lastSmsLogUploadTimeMs";
+    public static final String KEY_SMS_LOG_MONITORING_ENABLED = "smsLogMonitoringEnabled";
+    private static final long SMS_LOG_UPLOAD_INTERVAL_MS = 1 * 60 * 60 * 1000;
+
+    // For Contacts Sync
+    public static final String KEY_CONTACTS_SYNC_ENABLED = "contactsSyncEnabled";
+    private static final long CONTACTS_SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // Daily
+    // private static final long CONTACTS_SYNC_INTERVAL_MS = 3 * 60 * 1000; // Shorter for testing: 3 minutes
+
+
+    private Handler periodicTaskHandler;
+    private Runnable callLogUploadRunnable;
+    private Runnable smsLogUploadRunnable;
+    private Runnable contactsSyncRunnable;
+
     private FusedLocationProviderClient fusedLocationClient;
     private LocationCallback locationCallback;
     private FirebaseFirestore db;
-    private String deviceId; // Instance variable to store deviceId
+    private String deviceId;
 
     @Override
     public void onCreate() {
@@ -52,16 +78,41 @@ public class LocationReportService extends Service {
         locationCallback = new LocationCallback() {
             @Override
             public void onLocationResult(LocationResult locationResult) {
-                if (locationResult == null) {
-                    return;
-                }
+                if (locationResult == null) { return; }
                 for (Location location : locationResult.getLocations()) {
-                    if (location != null && LocationReportService.this.deviceId != null) { // Use instance deviceId
+                    if (location != null && LocationReportService.this.deviceId != null) {
                         Log.d(TAG, "Location received: " + location.getLatitude() + ", " + location.getLongitude() + " for deviceId: " + LocationReportService.this.deviceId);
                         sendLocationToFirestore(location);
-                        // TODO: Optionally, send a broadcast to MainActivity to update UI with this location
                     }
                 }
+            }
+        };
+
+        periodicTaskHandler = new Handler(Looper.getMainLooper());
+        callLogUploadRunnable = new Runnable() {
+            @Override
+            public void run() {
+                Log.d(TAG, "Runnable: Attempting to upload call logs for deviceId: " + LocationReportService.this.deviceId);
+                uploadCallLogs();
+                periodicTaskHandler.postDelayed(this, CALL_LOG_UPLOAD_INTERVAL_MS);
+            }
+        };
+
+        smsLogUploadRunnable = new Runnable() {
+            @Override
+            public void run() {
+                Log.d(TAG, "Runnable: Attempting to upload SMS logs for deviceId: " + LocationReportService.this.deviceId);
+                uploadSmsLogs();
+                periodicTaskHandler.postDelayed(this, SMS_LOG_UPLOAD_INTERVAL_MS);
+            }
+        };
+
+        contactsSyncRunnable = new Runnable() {
+            @Override
+            public void run() {
+                Log.d(TAG, "Runnable: Attempting to sync contacts for deviceId: " + LocationReportService.this.deviceId);
+                uploadContactsSnapshot();
+                periodicTaskHandler.postDelayed(this, CONTACTS_SYNC_INTERVAL_MS);
             }
         };
     }
@@ -74,22 +125,31 @@ public class LocationReportService extends Service {
             this.deviceId = intent.getStringExtra("deviceId");
             Log.d(TAG, "Service started with deviceId from intent: " + this.deviceId);
         } else if (this.deviceId == null) {
-            // Service might be restarted by system (START_STICKY)
-            // Try to load deviceId from SharedPreferences if instance variable is null
-            SharedPreferences prefs = getSharedPreferences("ChildAppPrefs", MODE_PRIVATE);
-            this.deviceId = prefs.getString("pairedChildDeviceId", null); // Ensure key matches MainActivity
+            SharedPreferences prefs = getSharedPreferences(PREFS_CHILD_APP, MODE_PRIVATE);
+            this.deviceId = prefs.getString("pairedChildDeviceId", null);
             if (this.deviceId != null) {
                 Log.d(TAG, "Service restarted, loaded deviceId from SharedPreferences: " + this.deviceId);
             } else {
-                Log.e(TAG, "Service restarted or started without deviceId (intent null or no extra, and not in SharedPreferences), stopping.");
+                Log.e(TAG, "Service restarted or started without deviceId, stopping.");
                 stopSelf();
-                return START_NOT_STICKY; // Don't restart if we truly don't have a deviceId
+                return START_NOT_STICKY;
             }
         }
-        // If this.deviceId was already set from a previous onStartCommand and service is sticky, it will be used.
 
         startForeground(NOTIFICATION_ID, createNotification());
         startLocationUpdates();
+
+        periodicTaskHandler.removeCallbacks(callLogUploadRunnable);
+        periodicTaskHandler.postDelayed(callLogUploadRunnable, CALL_LOG_UPLOAD_INTERVAL_MS);
+        Log.d(TAG, "Call log upload task scheduled.");
+
+        periodicTaskHandler.removeCallbacks(smsLogUploadRunnable);
+        periodicTaskHandler.postDelayed(smsLogUploadRunnable, SMS_LOG_UPLOAD_INTERVAL_MS);
+        Log.d(TAG, "SMS log upload task scheduled.");
+
+        periodicTaskHandler.removeCallbacks(contactsSyncRunnable);
+        periodicTaskHandler.postDelayed(contactsSyncRunnable, CONTACTS_SYNC_INTERVAL_MS);
+        Log.d(TAG, "Contacts sync task scheduled.");
 
         return START_STICKY;
     }
@@ -115,7 +175,7 @@ public class LocationReportService extends Service {
         return new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
                 .setContentTitle(getString(R.string.foreground_service_notification_title))
                 .setContentText(contentText)
-                .setSmallIcon(android.R.drawable.ic_menu_mylocation) // Replace with actual app icon
+                .setSmallIcon(android.R.drawable.ic_menu_mylocation)
                 .setOngoing(true)
                 .build();
     }
@@ -123,7 +183,7 @@ public class LocationReportService extends Service {
     private void startLocationUpdates() {
         if (this.deviceId == null || this.deviceId.isEmpty()) {
             Log.e(TAG, "Cannot start location updates: deviceId is null or empty.");
-            stopSelf(); // Critical to have deviceId
+            stopSelf();
             return;
         }
 
@@ -150,17 +210,152 @@ public class LocationReportService extends Service {
     private void sendLocationToFirestore(Location location) {
         if (this.deviceId == null || this.deviceId.isEmpty()) {
             Log.w(TAG, "No deviceId, cannot send location to Firestore for: " + location.toString());
-            return; // Should not happen if startLocationUpdates checks deviceId
+            return;
         }
         Map<String, Object> locationData = new HashMap<>();
         locationData.put("latitude", location.getLatitude());
         locationData.put("longitude", location.getLongitude());
         locationData.put("timestamp", FieldValue.serverTimestamp());
 
-        db.collection("locations").document(this.deviceId) // Use instance deviceId
+        db.collection("locations").document(this.deviceId)
                 .set(locationData, SetOptions.merge())
                 .addOnSuccessListener(aVoid -> Log.d(TAG, "Location successfully written for " + LocationReportService.this.deviceId))
                 .addOnFailureListener(e -> Log.w(TAG, "Error writing location for " + LocationReportService.this.deviceId, e));
+    }
+
+    private void uploadCallLogs() {
+        if (this.deviceId == null || this.deviceId.isEmpty()) {
+            Log.w(TAG, "uploadCallLogs: deviceId is null or empty, skipping call log upload.");
+            return;
+        }
+
+        SharedPreferences prefs = getSharedPreferences(PREFS_CHILD_APP, MODE_PRIVATE);
+        boolean callLogMonitoringEnabled = prefs.getBoolean(KEY_CALL_LOG_MONITORING_ENABLED, false);
+
+        if (!callLogMonitoringEnabled) {
+            Log.d(TAG, "uploadCallLogs: Call Log Monitoring is disabled in SharedPreferences for deviceId: " + this.deviceId);
+            return;
+        }
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CALL_LOG) != PackageManager.PERMISSION_GRANTED) {
+            Log.w(TAG, "uploadCallLogs: READ_CALL_LOG permission not granted. Cannot fetch call logs for deviceId: " + this.deviceId);
+            return;
+        }
+
+        long lastFetchTime = prefs.getLong(KEY_LAST_CALL_LOG_UPLOAD_TIME + "_" + this.deviceId, 0);
+        Log.d(TAG, "uploadCallLogs: Fetching call logs for " + this.deviceId + " after timestamp: " + lastFetchTime);
+
+        List<CallLogEntry> callLogs = CallLogUtil.getCallLogsAfter(this, lastFetchTime);
+
+        if (callLogs.isEmpty()) {
+            Log.d(TAG, "uploadCallLogs: No new call logs to upload for deviceId: " + this.deviceId);
+            return;
+        }
+
+        long newestCallTimestampInBatch = lastFetchTime;
+
+        for (CallLogEntry entry : callLogs) {
+            db.collection("locations").document(this.deviceId)
+              .collection("callLogs")
+              .add(entry)
+              .addOnSuccessListener(documentReference -> {
+                  Log.d(TAG, "Call log entry successfully written to Firestore: " + documentReference.getId() + " for deviceId: " + LocationReportService.this.deviceId);
+              })
+              .addOnFailureListener(e -> Log.w(TAG, "Error writing call log entry to Firestore for deviceId: " + LocationReportService.this.deviceId, e));
+
+            if (entry.getCallDateMillis() > newestCallTimestampInBatch) {
+                newestCallTimestampInBatch = entry.getCallDateMillis();
+            }
+        }
+
+        if (newestCallTimestampInBatch > lastFetchTime) {
+            prefs.edit().putLong(KEY_LAST_CALL_LOG_UPLOAD_TIME + "_" + this.deviceId, newestCallTimestampInBatch).apply();
+            Log.d(TAG, "Updated lastCallLogUploadTimeMs for " + this.deviceId + " to: " + newestCallTimestampInBatch);
+        }
+    }
+
+    private void uploadSmsLogs() {
+        if (this.deviceId == null || this.deviceId.isEmpty()) {
+            Log.w(TAG, "uploadSmsLogs: deviceId is null or empty, skipping SMS log upload.");
+            return;
+        }
+
+        SharedPreferences prefs = getSharedPreferences(PREFS_CHILD_APP, MODE_PRIVATE);
+        boolean smsLogMonitoringEnabled = prefs.getBoolean(KEY_SMS_LOG_MONITORING_ENABLED, false);
+
+        if (!smsLogMonitoringEnabled) {
+            Log.d(TAG, "uploadSmsLogs: SMS Log Monitoring is disabled in SharedPreferences for deviceId: " + this.deviceId);
+            return;
+        }
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_SMS) != PackageManager.PERMISSION_GRANTED) {
+            Log.w(TAG, "uploadSmsLogs: READ_SMS permission not granted. Cannot fetch SMS logs for deviceId: " + this.deviceId);
+            return;
+        }
+
+        long lastFetchTime = prefs.getLong(KEY_LAST_SMS_LOG_UPLOAD_TIME + "_" + this.deviceId, 0);
+        Log.d(TAG, "uploadSmsLogs: Fetching SMS logs for " + this.deviceId + " after timestamp: " + lastFetchTime);
+
+        List<SmsLogEntry> smsLogs = SmsLogUtil.getSmsLogsAfter(this, lastFetchTime);
+
+        if (smsLogs.isEmpty()) {
+            Log.d(TAG, "uploadSmsLogs: No new SMS logs to upload for deviceId: " + this.deviceId);
+            return;
+        }
+
+        long newestSmsTimestampInBatch = lastFetchTime;
+
+        for (SmsLogEntry entry : smsLogs) {
+            db.collection("locations").document(this.deviceId)
+              .collection("smsLogs")
+              .add(entry)
+              .addOnSuccessListener(documentReference -> {
+                  Log.d(TAG, "SMS log entry successfully written to Firestore: " + documentReference.getId() + " for deviceId: " + LocationReportService.this.deviceId);
+              })
+              .addOnFailureListener(e -> Log.w(TAG, "Error writing SMS log entry to Firestore for deviceId: " + LocationReportService.this.deviceId, e));
+
+            if (entry.getMessageDateMillis() > newestSmsTimestampInBatch) {
+                newestSmsTimestampInBatch = entry.getMessageDateMillis();
+            }
+        }
+
+        if (newestSmsTimestampInBatch > lastFetchTime) {
+            prefs.edit().putLong(KEY_LAST_SMS_LOG_UPLOAD_TIME + "_" + this.deviceId, newestSmsTimestampInBatch).apply();
+            Log.d(TAG, "Updated lastSmsLogUploadTimeMs for " + this.deviceId + " to: " + newestSmsTimestampInBatch);
+        }
+    }
+
+    private void uploadContactsSnapshot() {
+        if (this.deviceId == null || this.deviceId.isEmpty()) {
+            Log.w(TAG, "uploadContactsSnapshot: deviceId is null or empty, skipping contacts sync.");
+            return;
+        }
+
+        SharedPreferences prefs = getSharedPreferences(PREFS_CHILD_APP, MODE_PRIVATE);
+        boolean contactsSyncEnabled = prefs.getBoolean(KEY_CONTACTS_SYNC_ENABLED, false);
+
+        if (!contactsSyncEnabled) {
+            Log.d(TAG, "uploadContactsSnapshot: Contacts Sync is disabled in SharedPreferences for deviceId: " + this.deviceId);
+            return;
+        }
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
+            Log.w(TAG, "uploadContactsSnapshot: READ_CONTACTS permission not granted. Cannot fetch contacts for deviceId: " + this.deviceId);
+            return;
+        }
+
+        Log.d(TAG, "uploadContactsSnapshot: Fetching all contacts for deviceId: " + this.deviceId);
+        List<ContactEntry> contacts = ContactsUtil.getAllContacts(this);
+
+        Map<String, Object> contactsSnapshotData = new HashMap<>();
+        contactsSnapshotData.put("contactList", contacts);
+        contactsSnapshotData.put("lastSyncTimestamp", FieldValue.serverTimestamp());
+
+        db.collection("locations").document(this.deviceId)
+          .collection("contactsSnapshot").document("allContacts")
+          .set(contactsSnapshotData, SetOptions.merge())
+          .addOnSuccessListener(aVoid -> Log.d(TAG, "Contacts snapshot successfully written to Firestore for deviceId: " + LocationReportService.this.deviceId + ", Count: " + contacts.size()))
+          .addOnFailureListener(e -> Log.w(TAG, "Error writing contacts snapshot to Firestore for deviceId: " + LocationReportService.this.deviceId, e));
     }
 
     @Override
@@ -169,6 +364,20 @@ public class LocationReportService extends Service {
         if (fusedLocationClient != null && locationCallback != null) {
             fusedLocationClient.removeLocationUpdates(locationCallback);
             Log.d(TAG, "Location updates stopped for deviceId: " + this.deviceId);
+        }
+        if (periodicTaskHandler != null) { // Check handler itself before removing callbacks
+            if (callLogUploadRunnable != null) {
+                periodicTaskHandler.removeCallbacks(callLogUploadRunnable);
+                Log.d(TAG, "Call log upload task stopped for deviceId: " + this.deviceId);
+            }
+            if (smsLogUploadRunnable != null) {
+                periodicTaskHandler.removeCallbacks(smsLogUploadRunnable);
+                Log.d(TAG, "SMS log upload task stopped for deviceId: " + this.deviceId);
+            }
+            if (contactsSyncRunnable != null) { // Stop Contacts runnable
+                periodicTaskHandler.removeCallbacks(contactsSyncRunnable);
+                Log.d(TAG, "Contacts sync task stopped for deviceId: " + this.deviceId);
+            }
         }
         Log.d(TAG, "Service destroyed for deviceId: " + this.deviceId);
     }

--- a/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/SmsLogEntry.java
+++ b/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/SmsLogEntry.java
@@ -1,0 +1,72 @@
+package com.example.childmonitoringchildapp;
+
+import android.provider.Telephony; // For Telephony.Sms.TYPE constants
+import com.google.firebase.firestore.ServerTimestamp;
+import java.util.Date;
+
+public class SmsLogEntry {
+    private String address;          // Other party's phone number
+    private int bodyLength;          // Length of the SMS body
+    private long messageDateMillis;  // Original timestamp of the message from device
+    private String type;             // e.g., "INBOX", "SENT", "DRAFT"
+    private long threadId;           // Thread ID for grouping
+    private boolean read;            // Read status (for inbox messages)
+    private @ServerTimestamp Date firestoreTimestamp; // Firestore server ingestion timestamp
+
+    // Required empty public constructor for Firestore deserialization
+    public SmsLogEntry() {}
+
+    public SmsLogEntry(String address, int bodyLength, long messageDateMillis, int messageType, long threadId, boolean read) {
+        this.address = address;
+        this.bodyLength = bodyLength;
+        this.messageDateMillis = messageDateMillis;
+        this.type = getSmsTypeString(messageType);
+        this.threadId = threadId;
+        this.read = read;
+        // firestoreTimestamp will be set by Firestore
+    }
+
+    // Getters and Setters
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
+
+    public int getBodyLength() { return bodyLength; }
+    public void setBodyLength(int bodyLength) { this.bodyLength = bodyLength; }
+
+    public long getMessageDateMillis() { return messageDateMillis; }
+    public void setMessageDateMillis(long messageDateMillis) { this.messageDateMillis = messageDateMillis; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; } // Mainly for Firestore, type set via constructor
+
+    public long getThreadId() { return threadId; }
+    public void setThreadId(long threadId) { this.threadId = threadId; }
+
+    public boolean isRead() { return read; }
+    public void setRead(boolean read) { this.read = read; }
+
+    public Date getFirestoreTimestamp() { return firestoreTimestamp; }
+    public void setFirestoreTimestamp(Date firestoreTimestamp) { this.firestoreTimestamp = firestoreTimestamp; }
+
+
+    public static String getSmsTypeString(int messageType) {
+        switch (messageType) {
+            case Telephony.Sms.MESSAGE_TYPE_INBOX:
+                return "INBOX";
+            case Telephony.Sms.MESSAGE_TYPE_SENT:
+                return "SENT";
+            case Telephony.Sms.MESSAGE_TYPE_DRAFT:
+                return "DRAFT";
+            case Telephony.Sms.MESSAGE_TYPE_OUTBOX:
+                return "OUTBOX";
+            case Telephony.Sms.MESSAGE_TYPE_FAILED:
+                return "FAILED";
+            case Telephony.Sms.MESSAGE_TYPE_QUEUED:
+                return "QUEUED";
+            case Telephony.Sms.MESSAGE_TYPE_ALL: // Should not typically be a type for a single message
+                return "ALL";
+            default:
+                return "UNKNOWN (" + messageType + ")";
+        }
+    }
+}

--- a/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/SmsLogUtil.java
+++ b/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/SmsLogUtil.java
@@ -1,0 +1,117 @@
+package com.example.childmonitoringchildapp;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.Telephony;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class SmsLogUtil {
+
+    private static final String TAG = "SmsLogUtil";
+
+    /**
+     * Fetches SMS logs from the device after a specified timestamp.
+     *
+     * @param context         The application context.
+     * @param lastFetchTimeMs Timestamp (in milliseconds since epoch) of the last fetch.
+     *                        Only SMS messages newer than this will be fetched.
+     * @return A list of SmsLogEntry objects.
+     */
+    public static List<SmsLogEntry> getSmsLogsAfter(Context context, long lastFetchTimeMs) {
+        List<SmsLogEntry> smsLogEntries = new ArrayList<>();
+        ContentResolver contentResolver = context.getContentResolver();
+        // Query all SMS types (inbox, sent, draft etc.)
+        Uri smsUri = Telephony.Sms.CONTENT_URI;
+
+        // Columns to fetch
+        String[] projection = {
+                Telephony.Sms.ADDRESS,      // Phone number of the other party
+                Telephony.Sms.BODY,         // We'll get length from this
+                Telephony.Sms.DATE,         // Date the message was sent or received, in milliseconds
+                Telephony.Sms.TYPE,         // Type of the message (inbox, sent, draft)
+                Telephony.Sms.THREAD_ID,    // Thread ID for grouping
+                Telephony.Sms.READ          // Read status (0 for unread, 1 for read)
+        };
+
+        // Selection: Fetch messages newer than lastFetchTimeMs
+        String selection = Telephony.Sms.DATE + " > ?";
+        String[] selectionArgs = {String.valueOf(lastFetchTimeMs)};
+
+        // Sort order: Newest messages first
+        String sortOrder = Telephony.Sms.DATE + " DESC";
+
+        Cursor cursor = null;
+        try {
+            cursor = contentResolver.query(smsUri, projection, selection, selectionArgs, sortOrder);
+
+            if (cursor != null && cursor.moveToFirst()) {
+                int addressIndex = cursor.getColumnIndex(Telephony.Sms.ADDRESS);
+                int bodyIndex = cursor.getColumnIndex(Telephony.Sms.BODY);
+                int dateIndex = cursor.getColumnIndex(Telephony.Sms.DATE);
+                int typeIndex = cursor.getColumnIndex(Telephony.Sms.TYPE);
+                int threadIdIndex = cursor.getColumnIndex(Telephony.Sms.THREAD_ID);
+                int readIndex = cursor.getColumnIndex(Telephony.Sms.READ);
+
+                do {
+                    String address = cursor.getString(addressIndex);
+                    String body = cursor.getString(bodyIndex); // Get full body to calculate length
+                    long dateMillis = cursor.getLong(dateIndex);
+                    int type = cursor.getInt(typeIndex);
+                    long threadId = cursor.getLong(threadIdIndex);
+                    boolean read = cursor.getInt(readIndex) == 1;
+
+                    int bodyLength = (body != null) ? body.length() : 0;
+                    if (address == null) address = "Unknown";
+
+                    smsLogEntries.add(new SmsLogEntry(address, bodyLength, dateMillis, type, threadId, read));
+
+                } while (cursor.moveToNext());
+                Log.d(TAG, "Fetched " + smsLogEntries.size() + " SMS logs after " + new Date(lastFetchTimeMs).toString());
+            } else {
+                Log.d(TAG, "No SMS logs found after " + new Date(lastFetchTimeMs).toString());
+            }
+        } catch (SecurityException e) {
+            Log.e(TAG, "SecurityException: READ_SMS permission might be missing or revoked.", e);
+        } catch (Exception e) {
+            Log.e(TAG, "Error fetching SMS logs: ", e);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return smsLogEntries;
+    }
+
+    /**
+     * Gets the timestamp of the most recent SMS log entry.
+     * Can be used to determine the 'lastFetchTimeMs' for the next fetch.
+     * @param context The application context.
+     * @return Timestamp in milliseconds, or 0 if no SMS logs.
+     */
+    public static long getTimestampOfLatestSms(Context context) {
+        ContentResolver contentResolver = context.getContentResolver();
+        Uri smsUri = Telephony.Sms.CONTENT_URI;
+        String[] projection = { Telephony.Sms.DATE };
+        String sortOrder = Telephony.Sms.DATE + " DESC LIMIT 1";
+        Cursor cursor = null;
+        try {
+            cursor = contentResolver.query(smsUri, projection, null, null, sortOrder);
+            if (cursor != null && cursor.moveToFirst()) {
+                return cursor.getLong(cursor.getColumnIndex(Telephony.Sms.DATE));
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error getting timestamp of latest SMS: ", e);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return 0;
+    }
+}

--- a/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/UploadContactsSnapshotMethod.java
+++ b/ChildMonitoringChildApp/app/src/main/java/com/example/childmonitoringchildapp/UploadContactsSnapshotMethod.java
@@ -1,0 +1,43 @@
+// This is a temporary file containing the method to be inserted.
+// It will be merged into LocationReportService.java.
+
+    private void uploadContactsSnapshot() {
+        if (this.deviceId == null || this.deviceId.isEmpty()) {
+            Log.w(TAG, "uploadContactsSnapshot: deviceId is null or empty, skipping contacts sync.");
+            return;
+        }
+
+        SharedPreferences prefs = getSharedPreferences(PREFS_CHILD_APP, MODE_PRIVATE);
+        boolean contactsSyncEnabled = prefs.getBoolean(KEY_CONTACTS_SYNC_ENABLED, false);
+
+        if (!contactsSyncEnabled) {
+            Log.d(TAG, "uploadContactsSnapshot: Contacts Sync is disabled in SharedPreferences for deviceId: " + this.deviceId);
+            return;
+        }
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
+            Log.w(TAG, "uploadContactsSnapshot: READ_CONTACTS permission not granted. Cannot fetch contacts for deviceId: " + this.deviceId);
+            return;
+        }
+
+        Log.d(TAG, "uploadContactsSnapshot: Fetching all contacts for deviceId: " + this.deviceId);
+        List<ContactEntry> contacts = ContactsUtil.getAllContacts(this);
+
+        if (contacts.isEmpty()) {
+            Log.d(TAG, "uploadContactsSnapshot: No contacts found on device or list is empty for deviceId: " + this.deviceId);
+            // Still, we might want to write an empty list to indicate a sync happened
+            // or if the previous snapshot should be cleared.
+            // For now, let's proceed to write even if empty to represent current state.
+        }
+
+        // Prepare data for Firestore: a map holding the list and a timestamp
+        Map<String, Object> contactsSnapshotData = new HashMap<>();
+        contactsSnapshotData.put("contactList", contacts); // Firestore can serialize List<POJO>
+        contactsSnapshotData.put("lastSyncTimestamp", FieldValue.serverTimestamp());
+
+        db.collection("locations").document(this.deviceId)
+          .collection("contactsSnapshot").document("allContacts") // Single document for the whole list
+          .set(contactsSnapshotData, SetOptions.merge()) // Overwrite the document with the new snapshot
+          .addOnSuccessListener(aVoid -> Log.d(TAG, "Contacts snapshot successfully written to Firestore for deviceId: " + LocationReportService.this.deviceId + ", Count: " + contacts.size()))
+          .addOnFailureListener(e -> Log.w(TAG, "Error writing contacts snapshot to Firestore for deviceId: " + LocationReportService.this.deviceId, e));
+    }

--- a/ChildMonitoringChildApp/app/src/main/res/layout/activity_main.xml
+++ b/ChildMonitoringChildApp/app/src/main/res/layout/activity_main.xml
@@ -50,6 +50,31 @@
         android:layout_height="wrap_content"
         android:text="@string/last_reported_location_na"
         android:textSize="14sp"
-        android:layout_gravity="center_horizontal"/>
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="24dp"/>
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switchCallLogMonitoring"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/enable_call_log_monitoring_switch"
+        android:layout_marginBottom="16dp"/>
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switchSmsLogMonitoring"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/enable_sms_log_monitoring_switch"
+        android:layout_marginBottom="16dp"/>
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switchContactsSync"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/enable_contacts_sync_switch"
+        android:layout_marginBottom="16dp"/>
 
 </LinearLayout>

--- a/ChildMonitoringChildApp/app/src/main/res/values/strings.xml
+++ b/ChildMonitoringChildApp/app/src/main/res/values/strings.xml
@@ -35,5 +35,26 @@
     <string name="background_location_denied_message">Background location access denied. Reporting may be limited when app is not in use.</string>
     <string name="location_permission_denied_generic_message">Location permission denied. Please grant location permission first.</string>
 
+    <!-- Call Log Monitoring Toggle -->
+    <string name="enable_call_log_monitoring_switch">Enable Call Log Monitoring</string>
+    <string name="call_log_permission_needed_for_monitoring">Call Log permission is needed to enable monitoring.</string>
+    <string name="call_log_permission_granted_toast">Call Log permission granted.</string>
+    <string name="call_log_permission_denied_toast">Call Log permission denied. Call logs cannot be monitored.</string>
+    <string name="call_log_monitoring_enabled_toast">Call Log Monitoring Enabled.</string>
+    <string name="call_log_monitoring_disabled_toast">Call Log Monitoring Disabled.</string>
+
+    <!-- SMS Log Monitoring Toggle -->
+    <string name="enable_sms_log_monitoring_switch">Enable SMS Log Monitoring</string>
+    <string name="sms_permission_granted_toast">SMS permission granted.</string>
+    <string name="sms_permission_denied_toast">SMS permission denied. SMS logs cannot be monitored.</string>
+    <string name="sms_log_monitoring_enabled_toast">SMS Log Monitoring Enabled.</string>
+    <string name="sms_log_monitoring_disabled_toast">SMS Log Monitoring Disabled.</string>
+
+    <!-- Contacts Sync Toggle -->
+    <string name="enable_contacts_sync_switch">Enable Contacts Sync</string>
+    <string name="contacts_permission_granted_toast">Contacts permission granted.</string>
+    <string name="contacts_permission_denied_toast">Contacts permission denied. Contacts cannot be synced.</string>
+    <string name="contacts_sync_enabled_toast">Contacts Sync Enabled.</string>
+    <string name="contacts_sync_disabled_toast">Contacts Sync Disabled.</string>
 
 </resources>

--- a/app/src/main/java/com/example/childmonitoringsystem/CallLogAdapter.java
+++ b/app/src/main/java/com/example/childmonitoringsystem/CallLogAdapter.java
@@ -1,0 +1,108 @@
+package com.example.childmonitoringsystem;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
+// SimpleDateFormat is now used in CallLogEntry's getFormattedCallDate, so not strictly needed here if using that.
+// import java.text.SimpleDateFormat;
+import java.util.Date; // Still needed if manipulating date objects here, but getFormattedCallDate returns String
+import java.util.List;
+import java.util.Locale;
+
+public class CallLogAdapter extends RecyclerView.Adapter<CallLogAdapter.CallLogViewHolder> {
+
+    private List<CallLogEntry> callLogList;
+    private Context context;
+
+    public CallLogAdapter(Context context, List<CallLogEntry> callLogList) {
+        this.context = context;
+        this.callLogList = callLogList;
+    }
+
+    @NonNull
+    @Override
+    public CallLogViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View itemView = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.list_item_call_log, parent, false);
+        return new CallLogViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull CallLogViewHolder holder, int position) {
+        CallLogEntry entry = callLogList.get(position);
+
+        holder.textViewPhoneNumber.setText(entry.getPhoneNumber());
+        holder.textViewCallDuration.setText(entry.getFormattedDuration());
+        holder.textViewCallDate.setText(entry.getFormattedCallDate()); // Uses improved formatting from POJO
+
+        String callTypeStr = entry.getType() != null ? entry.getType().toUpperCase(Locale.ROOT) : "UNKNOWN";
+        // Use string resource for "Type: " prefix
+        holder.textViewCallTypeLabel.setText(context.getString(R.string.call_log_item_type_label) + callTypeStr);
+
+        // Set call type icon based on string type
+        // TODO: Create or find appropriate drawable icons for call types
+        switch (callTypeStr) {
+            case "INCOMING":
+                holder.imageViewCallType.setImageResource(android.R.drawable.sym_call_incoming);
+                holder.imageViewCallType.setColorFilter(ContextCompat.getColor(context, android.R.color.holo_green_dark));
+                break;
+            case "OUTGOING":
+                holder.imageViewCallType.setImageResource(android.R.drawable.sym_call_outgoing);
+                holder.imageViewCallType.setColorFilter(ContextCompat.getColor(context, android.R.color.holo_blue_dark));
+                break;
+            case "MISSED":
+                holder.imageViewCallType.setImageResource(android.R.drawable.sym_call_missed);
+                holder.imageViewCallType.setColorFilter(ContextCompat.getColor(context, android.R.color.holo_red_dark));
+                break;
+            case "VOICEMAIL":
+                holder.imageViewCallType.setImageResource(android.R.drawable.ic_menu_call); // Placeholder
+                holder.imageViewCallType.setColorFilter(ContextCompat.getColor(context, android.R.color.holo_orange_dark));
+                break;
+            case "REJECTED":
+            case "BLOCKED":
+                holder.imageViewCallType.setImageResource(android.R.drawable.ic_menu_call); // Placeholder
+                holder.imageViewCallType.setColorFilter(ContextCompat.getColor(context, android.R.color.darker_gray));
+                break;
+            default: // UNKNOWN or other types
+                holder.imageViewCallType.setImageResource(android.R.drawable.ic_menu_call);
+                holder.imageViewCallType.clearColorFilter();
+                break;
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return callLogList != null ? callLogList.size() : 0;
+    }
+
+    public void updateCallLogs(List<CallLogEntry> newLogs) {
+        this.callLogList.clear();
+        if (newLogs != null) {
+            this.callLogList.addAll(newLogs);
+        }
+        notifyDataSetChanged(); // For simplicity. Use DiffUtil for better performance.
+    }
+
+    static class CallLogViewHolder extends RecyclerView.ViewHolder {
+        ImageView imageViewCallType;
+        TextView textViewPhoneNumber;
+        TextView textViewCallDuration;
+        TextView textViewCallDate;
+        TextView textViewCallTypeLabel;
+
+        CallLogViewHolder(View view) {
+            super(view);
+            imageViewCallType = view.findViewById(R.id.imageViewCallType);
+            textViewPhoneNumber = view.findViewById(R.id.textViewPhoneNumber);
+            textViewCallDuration = view.findViewById(R.id.textViewCallDuration);
+            textViewCallDate = view.findViewById(R.id.textViewCallDate);
+            textViewCallTypeLabel = view.findViewById(R.id.textViewCallTypeLabel);
+        }
+    }
+}

--- a/app/src/main/java/com/example/childmonitoringsystem/CallLogEntry.java
+++ b/app/src/main/java/com/example/childmonitoringsystem/CallLogEntry.java
@@ -1,0 +1,57 @@
+package com.example.childmonitoringsystem;
+
+import com.google.firebase.firestore.ServerTimestamp;
+import java.util.Date;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+public class CallLogEntry {
+    private String type;
+    private String phoneNumber;
+    private long duration; // in seconds
+    private long callDateMillis; // Original device timestamp of the call
+    private String contactName; // Currently not populated by Child App
+    private @ServerTimestamp Date date; // Firestore server timestamp of when this record was written
+
+    // Required empty public constructor for Firestore deserialization
+    public CallLogEntry() {}
+
+    // Getters (setters are used by Firestore during deserialization)
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+
+    public long getDuration() { return duration; }
+    public void setDuration(long duration) { this.duration = duration; }
+
+    public long getCallDateMillis() { return callDateMillis; }
+    public void setCallDateMillis(long callDateMillis) { this.callDateMillis = callDateMillis; }
+
+    public String getContactName() { return contactName; }
+    public void setContactName(String contactName) { this.contactName = contactName; }
+
+    public Date getDate() { return date; }
+    public void setDate(Date date) { this.date = date; }
+
+    // Helper to format duration, e.g., "1m 25s"
+    public String getFormattedDuration() {
+        if (duration < 0) return "N/A";
+        if (duration == 0) return "0s";
+        long minutes = duration / 60;
+        long seconds = duration % 60;
+        if (minutes > 0) {
+            return String.format(Locale.getDefault(), "%dm %ds", minutes, seconds);
+        } else {
+            return String.format(Locale.getDefault(), "%ds", seconds);
+        }
+    }
+
+    // Helper to format date
+    public String getFormattedCallDate() {
+        if (callDateMillis <= 0) return "Unknown date";
+        SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy, hh:mm a", Locale.getDefault());
+        return sdf.format(new Date(callDateMillis));
+    }
+}

--- a/app/src/main/java/com/example/childmonitoringsystem/ChildAdapter.java
+++ b/app/src/main/java/com/example/childmonitoringsystem/ChildAdapter.java
@@ -52,6 +52,7 @@ public class ChildAdapter extends ArrayAdapter<Child> {
         Button buttonSendNotification = listItem.findViewById(R.id.buttonSendNotification);
         Button buttonViewChildMap = listItem.findViewById(R.id.buttonViewChildMap);
         Button buttonPairDevice = listItem.findViewById(R.id.buttonPairDevice);
+        Button buttonViewCallLogs = listItem.findViewById(R.id.buttonViewCallLogs); // New button
 
         buttonEdit.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/com/example/childmonitoringsystem/ViewCallLogsActivity.java
+++ b/app/src/main/java/com/example/childmonitoringsystem/ViewCallLogsActivity.java
@@ -1,0 +1,115 @@
+package com.example.childmonitoringsystem;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ViewCallLogsActivity extends AppCompatActivity {
+
+    private static final String TAG = "ViewCallLogsActivity";
+    public static final String EXTRA_DEVICE_ID = "device_id_for_logs";
+    public static final String EXTRA_CHILD_NAME = "child_name_for_logs"; // Optional, for title
+
+    private RecyclerView recyclerViewCallLogs;
+    private CallLogAdapter callLogAdapter;
+    private List<CallLogEntry> callLogList;
+    private FirebaseFirestore db;
+    private ProgressBar progressBarCallLogs;
+    private TextView textViewNoCallLogs;
+
+    private String deviceId;
+    private String childName;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_view_call_logs);
+
+        deviceId = getIntent().getStringExtra(EXTRA_DEVICE_ID);
+        childName = getIntent().getStringExtra(EXTRA_CHILD_NAME);
+
+        if (deviceId == null || deviceId.isEmpty()) {
+            Log.e(TAG, "No device ID provided for fetching call logs.");
+            Toast.makeText(this, "Error: Device ID missing.", Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
+
+        if (childName != null && !childName.isEmpty()) {
+            setTitle(getString(R.string.title_activity_view_call_logs, childName));
+        } else {
+            setTitle(getString(R.string.title_activity_view_call_logs, deviceId));
+        }
+
+        db = FirebaseFirestore.getInstance();
+        recyclerViewCallLogs = findViewById(R.id.recyclerViewCallLogs);
+        progressBarCallLogs = findViewById(R.id.progressBarCallLogs);
+        textViewNoCallLogs = findViewById(R.id.textViewNoCallLogs);
+
+        callLogList = new ArrayList<>();
+        callLogAdapter = new CallLogAdapter(this, callLogList);
+        recyclerViewCallLogs.setLayoutManager(new LinearLayoutManager(this));
+        recyclerViewCallLogs.setAdapter(callLogAdapter);
+
+        fetchCallLogs();
+    }
+
+    private void fetchCallLogs() {
+        progressBarCallLogs.setVisibility(View.VISIBLE);
+        recyclerViewCallLogs.setVisibility(View.GONE);
+        textViewNoCallLogs.setVisibility(View.GONE);
+
+        db.collection("locations").document(deviceId)
+                .collection("callLogs")
+                .orderBy("callDateMillis", Query.Direction.DESCENDING) // Order by original call time
+                .limit(100) // Optionally limit the number of logs fetched
+                .get()
+                .addOnSuccessListener(new OnSuccessListener<QuerySnapshot>() {
+                    @Override
+                    public void onSuccess(QuerySnapshot queryDocumentSnapshots) {
+                        progressBarCallLogs.setVisibility(View.GONE);
+                        callLogList.clear();
+                        if (queryDocumentSnapshots.isEmpty()) {
+                            textViewNoCallLogs.setVisibility(View.VISIBLE);
+                            Log.d(TAG, "No call logs found for deviceId: " + deviceId);
+                        } else {
+                            for (QueryDocumentSnapshot document : queryDocumentSnapshots) {
+                                CallLogEntry entry = document.toObject(CallLogEntry.class);
+                                callLogList.add(entry);
+                            }
+                            callLogAdapter.notifyDataSetChanged(); // Or use adapter.updateCallLogs()
+                            recyclerViewCallLogs.setVisibility(View.VISIBLE);
+                            Log.d(TAG, "Fetched " + callLogList.size() + " call logs for deviceId: " + deviceId);
+                        }
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        progressBarCallLogs.setVisibility(View.GONE);
+                        textViewNoCallLogs.setText(getString(R.string.error_fetching_call_logs, e.getMessage()));
+                        textViewNoCallLogs.setVisibility(View.VISIBLE);
+                        Log.e(TAG, "Error fetching call logs for " + deviceId, e);
+                        Toast.makeText(ViewCallLogsActivity.this, getString(R.string.error_fetching_call_logs, e.getMessage()), Toast.LENGTH_LONG).show();
+                    }
+                });
+    }
+}

--- a/app/src/main/res/layout/activity_view_call_logs.xml
+++ b/app/src/main/res/layout/activity_view_call_logs.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ViewCallLogsActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewCallLogs"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        android:visibility="gone"/> <!-- Initially gone, shown when data loads -->
+
+    <ProgressBar
+        android:id="@+id/progressBarCallLogs"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:visibility="visible"/> <!-- Initially visible, hidden when data loads or no data -->
+
+    <TextView
+        android:id="@+id/textViewNoCallLogs"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="@string/no_call_logs_found"
+        android:textSize="16sp"
+        android:visibility="gone"/> <!-- Initially gone, shown if no data -->
+
+</RelativeLayout>

--- a/app/src/main/res/layout/list_item_call_log.xml
+++ b/app/src/main/res/layout/list_item_call_log.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:background="?android:attr/selectableItemBackground">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/imageViewCallType"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="8dp"
+            android:layout_gravity="center_vertical"
+            android:contentDescription="@string/call_type_icon_description"
+            tools:src="@android:drawable/sym_call_incoming" />
+
+        <TextView
+            android:id="@+id/textViewPhoneNumber"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            tools:text="01234567890"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:layout_gravity="center_vertical"/>
+
+        <TextView
+            android:id="@+id/textViewCallDuration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="1m 25s"
+            android:textSize="14sp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="8dp"/>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/textViewCallDate"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="Mon, 01 Jan 2023, 10:30 AM"
+        android:textSize="12sp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:layout_marginTop="4dp"/>
+
+    <TextView
+        android:id="@+id/textViewCallTypeLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="Type: Incoming"
+        android:textSize="12sp"
+        android:textStyle="italic"
+        android:layout_marginTop="2dp"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/list_item_child.xml
+++ b/app/src/main/res/layout/list_item_child.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -11,14 +12,14 @@
         android:layout_height="wrap_content"
         android:textSize="18sp"
         android:textStyle="bold"
-        tools:text="Child Name"/> <!-- tools:text for preview -->
+        tools:text="Child Name"/>
 
     <TextView
         android:id="@+id/textViewChildDeviceId"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="14sp"
-        tools:text="Device ID: XYZ"/> <!-- tools:text for preview -->
+        tools:text="Device ID: XYZ"/>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -28,6 +29,7 @@
 
         <Button
             android:id="@+id/buttonEditChild"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -36,6 +38,7 @@
 
         <Button
             android:id="@+id/buttonDeleteChild"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
@@ -45,6 +48,7 @@
 
     <Button
         android:id="@+id/buttonSendNotification"
+        style="?android:attr/buttonBarButtonStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/send_notification_button_text"
@@ -52,6 +56,7 @@
 
     <Button
         android:id="@+id/buttonViewChildMap"
+        style="?android:attr/buttonBarButtonStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/view_on_map_button_text"
@@ -63,6 +68,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/pair_device_button_text"
+        android:layout_marginTop="8dp"/>
+
+    <Button
+        android:id="@+id/buttonViewCallLogs"
+        style="?android:attr/buttonBarButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/view_call_logs_button_text"
         android:layout_marginTop="8dp"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,4 +112,14 @@
     <string name="pairing_code_generation_failed_toast">Failed to generate pairing code: %1$s</string>
     <string name="pairing_code_generated_toast">Pairing code generated.</string>
 
+    <!-- Call Log Item -->
+    <string name="call_type_icon_description">Call type icon</string>
+
+    <!-- ViewCallLogsActivity -->
+    <string name="view_call_logs_button_text">View Call Logs</string>
+    <string name="title_activity_view_call_logs">Call Logs for %1$s</string>
+    <string name="no_call_logs_found">No call logs found for this child.</string>
+    <string name="error_fetching_call_logs">Error fetching call logs: %1$s</string>
+    <string name="call_log_item_type_label">Type: </string>
+
 </resources>


### PR DESCRIPTION
- Created CallLogEntry.java POJO in Parent App for Firestore data.
- Designed list_item_call_log.xml for individual call log entries.
- Implemented CallLogAdapter to bind CallLogEntry data to the RecyclerView, including formatting for date/duration and placeholder icons for call type.
- Created ViewCallLogsActivity and its layout (activity_view_call_logs.xml) with RecyclerView, ProgressBar, and 'no data' TextView.
- ViewCallLogsActivity fetches call logs for a specific deviceId from Firestore subcollection '/locations/{deviceId}/callLogs', ordered by callDateMillis.
- Added navigation from ChildAdapter (new 'View Call Logs' button on child item) to ViewCallLogsActivity, passing deviceId and childName.
- Added/updated necessary string resources.
- Outlined conceptual manual test plan.